### PR TITLE
Add additional tracking to popover actions

### DIFF
--- a/src/lib/components/donation-form.svelte
+++ b/src/lib/components/donation-form.svelte
@@ -32,7 +32,6 @@
 		donorStats,
 		class: className
 	} = $props();
-	const fundedPercentage = 60;
 	const buttonClass = twMerge(
 		'bg-white text-xl flex flex-row items-center justify-center outline-none focus:outline-none',
 		size === 'sm' && 'text-xl',
@@ -67,10 +66,10 @@
 			>
 		</div>
 		<div class="relative">
-			<ProgressBar percentage={fundedPercentage} {theme} {showPercentage} />
+			<ProgressBar percentage={donorStats ? donorStats.totalFundedPercent : 62} {theme} {showPercentage} />
 			<img
 				src={theme === 'dark' ? '/images/canman-flagman.png' : '/images/canman-flagman.png'}
-				class="w-20 sm:w-28 absolute bottom-3 -right-6"
+				class="w-20 lg:w-28 absolute bottom-3 -right-6"
 				alt="Can Man holding a flag with Cliff the Glyph"
 			/>
 		</div>

--- a/src/lib/components/header.svelte
+++ b/src/lib/components/header.svelte
@@ -70,16 +70,18 @@
 					<IconInstagram />
 				</a>
 
-				<input type="checkbox" id="support-trigger" class="popover-trigger peer" />
+				<input type="checkbox" id="popover-trigger" class="popover-trigger peer" />
 				<label
-					for="support-trigger"
-					class="min-w-36 popover-label support cursor-pointer inline-block peer-checked:hidden"
+					for="popover-trigger"
+					class="popover-open min-w-36 popover-label support cursor-pointer inline-block peer-checked:hidden"
+					id="popover-trigger-open"
 				>
 					Support Us
 				</label>
 				<label
-					for="support-trigger"
-					class="close-button min-w-36 popover-label support cursor-pointer hidden peer-checked:flex flex-row items-center justify-end gap-2"
+					for="popover-trigger"
+					class="popover-close min-w-36 popover-label support cursor-pointer hidden peer-checked:flex flex-row items-center justify-end gap-2"
+					id="popover-trigger-close"
 				>
 					<span>Support</span>
 					<svg

--- a/src/routes/+layout.js
+++ b/src/routes/+layout.js
@@ -4,8 +4,14 @@ export const csr = false;
 export async function load({ fetch }) {
 	const res = await fetch('https://donorstats.sydneymusic.net/donorstats.json');
 	const data = await res.json();
+	const sponsorPercent = 40;
+	const totalFundedPercent = Math.round(sponsorPercent + (data ? data.recurringBudgetPercent : 22));
 
 	return {
-		donorStats: data
+		donorStats: {
+			...data,
+			sponsorPercent,
+			totalFundedPercent
+		}
 	};
 }

--- a/static/js/support-popover.js
+++ b/static/js/support-popover.js
@@ -14,46 +14,59 @@ const supportPopoverConfig = [
 ];
 
 document.addEventListener('DOMContentLoaded', () => {
-
 	const createSupportPopover = (config) => {
-		const supportTrigger = document.getElementById('support-trigger');
-		const closeButton = document.querySelector('.close-button');
+		const popoverTrigger = document.getElementById('popover-trigger');
+		const openLabel = document.querySelector('.popover-open');
+		const closeLabel = document.querySelector('.popover-close');
 		const popoverContent = document.querySelector('.popover-content');
 
-		if (!supportTrigger || !popoverContent || !closeButton) {
-			console.error('Support popover elements not found', supportTrigger, popoverContent, closeButton);
+		if (!popoverTrigger || !popoverContent || !openLabel || !closeLabel) {
+			console.error(
+				'Support popover elements not found',
+				popoverTrigger,
+				popoverContent,
+				openLabel,
+				closeLabel
+			);
 			return null;
 		}
 
 		const closePopover = (evt) => {
-			supportTrigger.checked = false;
+			popoverTrigger.checked = false;
+			if (window && window.plausible) window.plausible('Close Support Popover', { interactive });
 
 			if (!evt) return;
 
 			// Set localStorage when close button is clicked
-			if (config.localStorageKey && evt.target.closest('.close-button')) {
+			if (config.localStorageKey && evt.target.closest('.popover-close')) {
 				localStorage.setItem(config.localStorageKey, 'true');
 			}
 		};
 
-		const handleOutsideClick = (event) => {
-			if (!popoverContent.contains(event.target) && !event.target.closest('.popover-label')) {
-				closePopover(false);
-			}
+		const openPopover = (interactive = true) => {
+			popoverTrigger.checked = true;
+			if (window && window.plausible)
+				window.plausible(`${interactive ? 'Open' : 'View'} Support Popover`, { interactive });
 		};
-
-		const openPopover = () => {
-			supportTrigger.checked = true;
-			document.addEventListener('click', handleOutsideClick);
-		};
-
-		closeButton.addEventListener('click', closePopover);
 
 		// Listen for checkbox changes to handle cleanup
-		supportTrigger.addEventListener('change', (e) => {
+		popoverTrigger.addEventListener('change', (e) => {
 			if (!e.target.checked) {
 				document.removeEventListener('click', handleOutsideClick);
 			}
+		});
+
+		// Add tracking to label actions
+		openLabel.addEventListener('click', (e) => {
+			e.preventDefault();
+			e.stopPropagation();
+			openPopover();
+		});
+
+		closeLabel.addEventListener('click', (e) => {
+			e.preventDefault();
+			e.stopPropagation();
+			closePopover(e);
 		});
 
 		return { openPopover };
@@ -71,7 +84,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		if (config.delay > 0) {
 			setTimeout(popover.openPopover, config.delay);
 		} else {
-			popover.openPopover();
+			popover.openPopover(false);
 		}
 	};
 


### PR DESCRIPTION
These changes adds plausible tracking for `View Support Popover` events so we can create funnels in analytics. It also captures the active 'Open' and 'Close' events for the popover.

Plus a couple of improvements to the current UI – getting more consistent layout and dismiss behaviors for the support popover

